### PR TITLE
Add a sudo method to recipe

### DIFF
--- a/lib/blazing/recipe.rb
+++ b/lib/blazing/recipe.rb
@@ -15,6 +15,12 @@ class Blazing::Recipe
     @options.merge! target_options
   end
 
+  private
+
+  def sudo
+    options[:sudo] || 'sudo'
+  end
+
   class << self
 
     def init_by_name(name, options = {})

--- a/spec/blazing/recipe_spec.rb
+++ b/spec/blazing/recipe_spec.rb
@@ -39,4 +39,16 @@ describe Blazing::Recipe do
     end
   end
 
+  describe '#sudo' do
+    it 'returns value passed as :sudo' do
+      @dummy_recipe = Blazing::Recipe::Dummy.new(:sudo => 'rvmsudo')
+      @dummy_recipe.send(:sudo).should == 'rvmsudo'
+    end
+
+    it 'returns sudo if no value passed' do
+      @dummy_recipe = Blazing::Recipe::Dummy.new
+      @dummy_recipe.send(:sudo).should == 'sudo'
+    end
+  end
+
 end


### PR DESCRIPTION
Can be used by recipes to specify a custom sudo command.

Use case:

I am making a couple of recipes that need to run with sudo(whenever and foreman). This allows them to run with rvmsudo if the user is using rvm, or some other custom sudo command if it is needed.
