### PR TITLE
use env for finding bash

### DIFF
--- a/lib/blazing/templates/hook/setup.erb
+++ b/lib/blazing/templates/hook/setup.erb
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "------"
 echo "------  [blazing] ENTERING POST RECEIVE HOOK FOR: <%= @target.name %>"


### PR DESCRIPTION
since blazing depends on bash
it would be good to use env.
e.g. freebs has bash not in /bin 