### PR TITLE
Fix compatibility issues with logging 2.0

### DIFF
--- a/blazing.gemspec
+++ b/blazing.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('pimpmychangelog')
 
   s.add_dependency('grit')
-  s.add_dependency('logging')
+  s.add_dependency('logging', '~> 1.8')
   s.add_dependency('thor')
 
   # TODO: Get rid of those, just used for guessing recipe names etc in lib/recipes.rb


### PR DESCRIPTION
Logging 2.0 was recently released and causes this error with Blazing
```
undefined method `consolidate' for Logging:Module
```
This will lock the version to 1.8 to work around this error until Blazing can be updated to be compatible with 2.0.