### PR TITLE
use correct parameter for target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 ---
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
-  - 2.1.0
+  - 2.1.6
+  - 2.2.2
 script:
  - bundle exec rake
  - bundle exec rubocop

--- a/lib/blazing/dsl.rb
+++ b/lib/blazing/dsl.rb
@@ -10,7 +10,8 @@ module Blazing
 
     def target(name, location, options = {})
       raise 'Name already taken' if config.targets.find { |t| t.name == name }
-      config.targets << Blazing::Target.new(name, location, self, options)
+
+      config.targets << Blazing::Target.new(name, location, self.config, options)
     end
 
     def rake(task_name)

--- a/lib/blazing/dsl.rb
+++ b/lib/blazing/dsl.rb
@@ -11,7 +11,7 @@ module Blazing
     def target(name, location, options = {})
       raise 'Name already taken' if config.targets.find { |t| t.name == name }
 
-      config.targets << Blazing::Target.new(name, location, self.config, options)
+      config.targets << Blazing::Target.new(name, location, config, options)
     end
 
     def rake(task_name)

--- a/spec/blazing/dsl_spec.rb
+++ b/spec/blazing/dsl_spec.rb
@@ -17,7 +17,7 @@ module Blazing
 
       it 'does not allow the creation of two targets with the same name' do
         dsl.target :somename, 'someuser@somehost:/path/to/deploy/to'
-        expect { dsl.target :somename, 'someuser@somehost:/path/to/deploy/to' }.to raise_error
+        expect { dsl.target :somename, 'someuser@somehost:/path/to/deploy/to' }.to raise_error(RuntimeError, 'Name already taken')
         expect(config.targets.size).to be 1
       end
     end


### PR DESCRIPTION
Hi @effkay,

[targets expects config as the third parameter](https://github.com/effkay/blazing/blob/master/lib/blazing/target.rb#L10) and this PR ensures this.

Thank you very much,
Alex
